### PR TITLE
Fix current-session.sh to work after cd

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-session-analysis",
   "description": "Analyze Claude Code session files (.jsonl) to view timeline, file operations, and version diffs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "kawaz"
   }

--- a/skills/claude-session-analysis/SKILL.md
+++ b/skills/claude-session-analysis/SKILL.md
@@ -11,7 +11,7 @@ description: Analyze Claude Code session files (.jsonl) to view timeline, file o
 
 | Script | Description |
 |--------|-------------|
-| `./scripts/current-session.sh [dir] [sec]` | Get session candidates (default: cwd, 300s) |
+| `./scripts/current-session.sh [sec]` | Get session candidates (default: 300s) |
 | `./scripts/sessions.sh [--all] [dir]` | List sessions (time, size, ID) |
 | `./scripts/timeline.sh <session-id>` | Timeline view (U/T/R/W markers) |
 | `./scripts/get-by-ref.sh [--raw] <session-id> <marker>` | Get entry details |

--- a/skills/claude-session-analysis/scripts/current-session.sh
+++ b/skills/claude-session-analysis/scripts/current-session.sh
@@ -2,19 +2,17 @@
 # Returns current session ID candidates
 # Claude identifies its own session by matching displays
 #
-# Usage: current-session.sh [project_path] [seconds]
-#   project_path: Project path (default: pwd)
+# Usage: current-session.sh [seconds]
 #   seconds: Time window in seconds (default: 300)
 #
-# Output: JSON with last 3 displays (15 chars each) per session
+# Output: JSON with sessionId, project, and last 3 displays (15 chars each) per session
 # Claude matches displays with its conversation to identify the correct session
 
-PROJECT_PATH="${1:-$(pwd -P)}"
-SECONDS_AGO="${2:-300}"
+SECONDS_AGO="${1:-300}"
 
-jq -sc --arg p "$PROJECT_PATH" --argjson sec "$SECONDS_AGO" '
-  [.[] | select(.project == $p and now - $sec < .timestamp/1000)]
+jq -sc --argjson sec "$SECONDS_AGO" '
+  [.[] | select(now - $sec < .timestamp/1000)]
   | group_by(.sessionId)[]
   | sort_by(.timestamp)[-3:]
-  | {sessionId: .[0].sessionId, displays: [.[].display[:15]]}
+  | {sessionId: .[0].sessionId, project: .[0].project, displays: [.[].display[:15]]}
 ' ~/.claude/history.jsonl


### PR DESCRIPTION
## Summary

- `current-session.sh` の project フィルタを削除し、時間のみでフィルタするように変更
- 出力 JSON に `project` フィールドを追加
- `dir` 引数を削除（不要になった）

## Problem

`cd` でディレクトリを移動すると、`current-session.sh` が `pwd` と `history.jsonl` の `project` フィールドを比較してセッションを検索していたため、セッションが見つからなくなる問題があった。

## Solution

`history.jsonl` から全プロジェクトを検索し、時間だけでフィルタする。出力に `project` フィールドを含めることで、どのプロジェクトのセッションか分かるようにした。

## Test

cd した状態で `current-session.sh` を実行し、正しくセッションが検出されることを確認済み。

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 3つの新しいスクリプト機能を追加しました。

* **変更**
  * スクリプトのパラメータ仕様を更新しました。データ検索方法が変更されています。

* **Chores**
  * プラグインバージョンを0.1.1に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->